### PR TITLE
Extended keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,12 @@
 //! # Examples
 //!
 //! ```rust
-//! use tinyminiscript::parse_script;
+//! use tinyminiscript::{parse_script, script::build_script};
 //!
 //! // Parse a simple miniscript
 //! let result = parse_script("wsh(multi(1,022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4,025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc))");
-//! if let Ok((ctx, script)) = result {
+//! if let Ok(ctx) = result {
+//!     let script = build_script(&ctx).unwrap();
 //!     println!("Successfully parsed miniscript");
 //!     println!("Generated script: {:?}", script);
 //! }
@@ -103,17 +104,20 @@ pub enum MiniscriptError<'a> {
 /// # Examples
 ///
 /// ```rust
-/// use tinyminiscript::parse_script;
+/// use tinyminiscript::{parse_script, script::build_script};
 ///
 /// let result = parse_script("pk(02e79c4c8b3c8b3c8b3c8b3c8b3c8b3c8b3c8b3c8b3c8b3c8b3c8b3c8b3c8b3)");
 /// match result {
-///     Ok((ctx, script)) => println!("Generated script: {:?}", script),
+///     Ok(ctx) => {
+///         let script = build_script(&ctx).unwrap();
+///         println!("Generated script: {:?}", script);
+///     }
 ///     Err(e) => eprintln!("Parse error: {:?}", e),
 /// }
 /// ```
 pub fn parse_script<'a>(
     script: &'a str,
-) -> Result<(ParserContext<'a>, ScriptBuf), MiniscriptError<'a>> {
+) -> Result<ParserContext<'a>, MiniscriptError<'a>> {
     let ctx = parser::parse(script).map_err(MiniscriptError::ParserError)?;
 
     // Type check the AST for correctness properties
@@ -138,8 +142,5 @@ pub fn parse_script<'a>(
     )
     .map_err(MiniscriptError::LimitsError)?;
 
-    // Generate the Bitcoin script
-    let script_buf = script::build_script(&ctx).map_err(MiniscriptError::ScriptBuilderError)?;
-
-    Ok((ctx, script_buf))
+    Ok(ctx)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub mod script;
 /// Type checking and correctness property validation
 pub mod type_checker;
 
+pub use bitcoin;
+
 pub extern crate alloc;
 pub(crate) type Vec<T> = alloc::vec::Vec<T>;
 

--- a/src/script.rs
+++ b/src/script.rs
@@ -20,6 +20,7 @@ pub enum ScriptBuilderError<'a> {
         position: Position,
         key: &'a str,
     },
+    NonDefiniteKey(alloc::string::String),
 }
 
 #[inline]
@@ -60,10 +61,18 @@ impl<'a> ScriptBuilder<'a> {
                 Ok(builder)
             }
             Fragment::PkK { key } => {
+                let key = match key.as_definite_key() {
+                    Some(k) => k,
+                    None => return Err(ScriptBuilderError::NonDefiniteKey(key.identifier())),
+                };
                 builder = key.push_to_script(builder);
                 Ok(builder)
             }
             Fragment::PkH { key } => {
+                let key = match key.as_definite_key() {
+                    Some(k) => k,
+                    None => return Err(ScriptBuilderError::NonDefiniteKey(key.identifier())),
+                };
                 let hash: PubkeyHash = key.pubkey_hash();
 
                 builder = builder

--- a/src/script.rs
+++ b/src/script.rs
@@ -60,17 +60,11 @@ impl<'a> ScriptBuilder<'a> {
                 Ok(builder)
             }
             Fragment::PkK { key } => {
-                builder = match &key {
-                    KeyType::PublicKey(k) => builder.push_key(k),
-                    KeyType::XOnlyPublicKey(k) => builder.push_x_only_key(k),
-                };
+                builder = key.push_to_script(builder);
                 Ok(builder)
             }
             Fragment::PkH { key } => {
-                let hash: PubkeyHash = match &key {
-                    KeyType::PublicKey(k) => k.pubkey_hash(),
-                    KeyType::XOnlyPublicKey(k) => PubkeyHash::hash(&k.serialize()),
-                };
+                let hash: PubkeyHash = key.pubkey_hash();
 
                 builder = builder
                     .push_opcode(opcodes::all::OP_DUP)

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -75,7 +75,8 @@ enum Error<'a> {
 }
 
 fn execute_script<'a>(script: &'a str) -> Result<(), Error<'a>> {
-    let (ctx, script_buf) = tinyminiscript::parse_script(script).map_err(Error::Miniscript)?;
+    let ctx = tinyminiscript::parse_script(script).map_err(Error::Miniscript)?;
+    let script_buf = tinyminiscript::script::build_script(&ctx).map_err(MiniscriptError::ScriptBuilderError).map_err(Error::Miniscript)?;
     // println!("ast: {}", ctx.print_ast());
     // println!("bitcoin script: {:?}", script_buf.to_asm_string());
 
@@ -103,7 +104,7 @@ impl Satisfier for TestSatisfier {
         None
     }
 
-    fn sign(&self, pubkey: &dyn tinyminiscript::parser::KeyTypeTrait) -> Option<(Vec<u8>, bool)> {
+    fn sign(&self, pubkey: &dyn tinyminiscript::parser::PublicKeyTrait) -> Option<(Vec<u8>, bool)> {
         Some((Vec::new(), false))
     }
 

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -103,11 +103,8 @@ impl Satisfier for TestSatisfier {
         None
     }
 
-    fn sign(&self, pubkey: &tinyminiscript::parser::KeyType) -> Option<(Vec<u8>, bool)> {
-        match pubkey {
-            tinyminiscript::parser::KeyType::PublicKey(pubkey) => Some((Vec::new(), false)),
-            tinyminiscript::parser::KeyType::XOnlyPublicKey(pubkey) => Some((Vec::new(), false)),
-        }
+    fn sign(&self, pubkey: &dyn tinyminiscript::parser::KeyTypeTrait) -> Option<(Vec<u8>, bool)> {
+        Some((Vec::new(), false))
     }
 
     fn preimage(


### PR DESCRIPTION
This PR switches to dynamic key types (we avoid using generics to keep the code size small) and implements extended keys that can be derived.

Extended keys can be derived to a specific index: we will use this to implement a way to "derive" a whole descriptor, which means recursively deriving all its keys internally. I think we can do that by implementing a new AST pass that goes over all the keys and calls `derive()` on them.

Derived descriptors are what is usually turned into actual bitcoin script: that's why i modified the parsing so that we only return the context and we later build the script when needed.